### PR TITLE
Allow deleting/halting of messages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   createMessage,
   dataPath,
   deleteChat,
+  deleteMessage,
   listChats,
   listMessages,
   renameChat,
@@ -235,6 +236,37 @@ app.on('ready', () => {
       window: BrowserWindow.fromWebContents(event.sender) ?? undefined
     })
   })
+
+  ipcMain.on(
+    'message:show-context-menu',
+    (event, chatId, messageId, isPartialMessage) => {
+      const template: MenuItemConstructorOptions[] = []
+
+      if (isPartialMessage) {
+        template.push({
+          label: 'Stop output',
+          click: () => {
+            chatController.abortMessageForChat(chatId)
+          }
+        })
+      } else {
+        template.push({
+          label: 'Delete message',
+          click: () => {
+            deleteMessage(chatId, messageId)
+            BrowserWindow.getAllWindows().forEach(window =>
+              window.webContents.send('message:deleted', chatId, messageId)
+            )
+          }
+        })
+      }
+
+      const menu = Menu.buildFromTemplate(template)
+      menu.popup({
+        window: BrowserWindow.fromWebContents(event.sender) ?? undefined
+      })
+    }
+  )
 
   globalShortcut.register('Control+Command+B', () => {
     const window = BrowserWindow.getAllWindows().at(0)

--- a/src/main/db/db.ts
+++ b/src/main/db/db.ts
@@ -135,6 +135,24 @@ export function listMessages(
   return chatState.messages
 }
 
+export function deleteMessage(chatId: number, messageId: number): void {
+  // First, read the chat state from disk.
+  const chatState = readChatState(chatId)
+
+  // Next, update the chat state.
+  chatState.messages = chatState.messages.filter(
+    message => message.id !== messageId
+  )
+
+  // Next, write the chat state to disk.
+  writeChatState(chatId, chatState)
+
+  // Finally, update the index.
+  const chat = assert(chatsIndex.chats.find(chat => chat.id === chatId))
+  chat.updatedAt = Date.now()
+  writeChatsIndex(chatsIndex)
+}
+
 function timestamps(creating: true): {createdAt: number; updatedAt: number}
 function timestamps(creating: false): {updatedAt: number}
 function timestamps(creating: boolean) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -70,6 +70,19 @@ const api = {
     ipcRenderer.send('chat-list:show-context-menu', chatId)
   },
 
+  showMessageContextMenu: (
+    chatId: number,
+    messageId: number,
+    isPartialMessage: boolean
+  ): void => {
+    ipcRenderer.send(
+      'message:show-context-menu',
+      chatId,
+      messageId,
+      isPartialMessage
+    )
+  },
+
   // Other events
   onChatCreated: (
     callback: (event: IpcRendererEvent, chat: Chat) => void
@@ -83,6 +96,17 @@ const api = {
   ): (() => void) => {
     ipcRenderer.on('chat:deleted', callback)
     return () => ipcRenderer.removeListener('chat:deleted', callback)
+  },
+
+  onMessageDeleted: (
+    callback: (
+      event: IpcRendererEvent,
+      chatId: number,
+      messageId: number
+    ) => void
+  ): (() => void) => {
+    ipcRenderer.on('message:deleted', callback)
+    return () => ipcRenderer.removeListener('message:deleted', callback)
   },
 
   onFocusNextChat: (

--- a/src/renderer/components/main.tsx
+++ b/src/renderer/components/main.tsx
@@ -46,6 +46,19 @@ export const Main: FC = () => {
     enabled: currentChat != null
   })
 
+  useEffect(() => {
+    const onMessageDeleted = (
+      event: IpcRendererEvent,
+      chatId: number,
+      messageId: number
+    ) => {
+      queryClient.invalidateQueries(['messages', chatId])
+      queryClient.invalidateQueries(['partial-message', chatId])
+    }
+
+    return api.onMessageDeleted(onMessageDeleted)
+  }, [queryClient])
+
   const messages = messagesQuery.data ?? []
 
   const createChat = useMutation({
@@ -151,6 +164,7 @@ export const Main: FC = () => {
             <div className="flex min-h-0 flex-1 flex-col">
               <MessageList
                 key={currentChat.id}
+                chatId={currentChat.id}
                 messages={messages}
                 partialMessageChunks={partialMessageQuery.data ?? null}
               />

--- a/src/renderer/components/message-list.tsx
+++ b/src/renderer/components/message-list.tsx
@@ -15,17 +15,22 @@ const isSystem = (message: Message) => {
 }
 
 interface Props {
+  chatId: number
   messages: Message[]
   partialMessageChunks: string[] | null
 }
 
-export const MessageList: FC<Props> = ({messages, partialMessageChunks}) => {
+export const MessageList: FC<Props> = ({
+  chatId,
+  messages,
+  partialMessageChunks
+}) => {
   const {query: modelQuery} = useConfigModel()
 
   const partialMessage: Message | null = partialMessageChunks
     ? {
         id: Math.random(),
-        chatId: Math.random(),
+        chatId: chatId,
         role: 'assistant',
         content: partialMessageChunks.join(''),
         createdAt: Date.now(),
@@ -41,6 +46,7 @@ export const MessageList: FC<Props> = ({messages, partialMessageChunks}) => {
             key={message.id}
             message={message}
             modelKey={modelQuery.data?.key ?? null}
+            isPartialMessage={message === partialMessage}
           />
         )
       )}
@@ -51,6 +57,7 @@ export const MessageList: FC<Props> = ({messages, partialMessageChunks}) => {
 interface MessageProps {
   message: Message
   modelKey: string | null
+  isPartialMessage: boolean
 }
 
 const messageClass = cva(['flex gap-4 border-b p-4'], {
@@ -76,9 +83,17 @@ const modelClass = cva(['flex-none h-6 w-6 rounded-full'], {
   }
 })
 
-function MessageListItem({message, modelKey}: MessageProps) {
+function MessageListItem({message, modelKey, isPartialMessage}: MessageProps) {
+  const onContextMenu = () => {
+    api.showMessageContextMenu(message.chatId, message.id, isPartialMessage)
+  }
+
   return (
-    <div className={messageClass({role: message.role})} key={message.id}>
+    <div
+      onContextMenu={onContextMenu}
+      className={messageClass({role: message.role})}
+      key={message.id}
+    >
       {isMe(message) ? (
         <div className="h-6 w-6 flex-none rounded-full bg-gradient-to-br from-indigo-500 to-emerald-500" />
       ) : isSystem(message) ? (


### PR DESCRIPTION
This allows users to delete any message, and to stop model output.

- **To delete**: Right click a message and click "Delete message"
- **To stop output**: Right click an in-progress message and click "Stop output"

When output is stopped, the message that has been streamed so far is persisted, and then can be optionally deleted.

https://user-images.githubusercontent.com/412282/234904862-315d1e64-4aff-4103-9e86-f3d7b92eb94d.mp4

